### PR TITLE
Remove egulias/email-validator dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,9 @@
     ],
     "require": {
         "php": ">=7.3",
-        "swiftmailer/swiftmailer": ">=6.2.7",
-        "guzzlehttp/guzzle": ">=6.0"
+        "egulias/email-validator": "^2.1.10|^3.1",
+        "guzzlehttp/guzzle": ">=6.0",
+        "swiftmailer/swiftmailer": ">=6.2.7"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.17",

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,7 @@
     "require": {
         "php": ">=7.3",
         "swiftmailer/swiftmailer": ">=6.2.7",
-        "guzzlehttp/guzzle": ">=6.0",
-        "egulias/email-validator": "^2.1.10"
+        "guzzlehttp/guzzle": ">=6.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.17",

--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,11 @@
     ],
     "require": {
         "php": ">=7.3",
-        "egulias/email-validator": "^2.1.10|^3.1",
         "guzzlehttp/guzzle": ">=6.0",
         "swiftmailer/swiftmailer": ">=6.2.7"
     },
     "require-dev": {
+        "egulias/email-validator": "^2.1.10|^3.1",
         "friendsofphp/php-cs-fixer": "^2.17",
         "phpunit/phpunit": "^9.5",
         "spatie/ray": "^1.10",


### PR DESCRIPTION
Hi. I just upgraded to Laravel v9, but noticed that it caused this package to be downgraded from v1.0.3 to v1.0.0. I think this is because the email validator package is a lower version than what Laravel v9 supports.

As far as I can see the email validator package is not used here, so perhaps it doesn't need to be required? Also, SwiftMailer appears to support both versions v2 and v3 of the email validator already, which covers Laravel v8 and v9: 

https://github.com/swiftmailer/swiftmailer/blob/v6.3.0/composer.json#L19
https://github.com/laravel/framework/blob/8.x/composer.json#L24
https://github.com/laravel/framework/blob/9.x/composer.json#L23

/cc @liamkeily https://github.com/mailpace/mailpace-swiftmailer/commit/b45c4621be70a7e5a08a65a2c2c46b1497f69b27

